### PR TITLE
added icon support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,8 @@ function electronPrompt(options, parentWindow) {
 			alwaysOnTop: false,
 			value: null,
 			type: 'input',
-			selectOptions: null
+			selectOptions: null,
+			icon: null
 		}, options || {});
 
 		if (opts.type === 'select' && (opts.selectOptions === null || typeof (opts.selectOptions) !== 'object')) {
@@ -34,7 +35,8 @@ function electronPrompt(options, parentWindow) {
 			alwaysOnTop: opts.alwaysOnTop,
 			useContentSize: true,
 			modal: Boolean(parentWindow),
-			title: opts.title
+			title: opts.title,
+			icon: opts.icon
 		});
 
 		promptWindow.setMenu(null);


### PR DESCRIPTION
I made a llittle weather app and used electron-prompt to ask users city.  
I wanted to change the icon to my own from electrons default and electron-prompt didn't 'inherit' the main icon, so I had to take look at your code in the node modules. It was simple enough to do and thought other users might find this a nice little addition to electron-prompt.  
So, with this little change you can do for example
````javascript
prompt({
    title: 'Prompt example',
    value: 'http://example.org',
    icon: path.join(__dirname, 'images/image.png')
})
.then(
    etc...
)
````  

and result
![2018-07-20_1740](https://user-images.githubusercontent.com/22402899/43009568-b41cab9e-8c46-11e8-82c2-d52b8b8949d1.png)

If one doesn't provide icon in the options, it defaults to null, which means electron uses its own default icon.  
![2018-07-20_1811](https://user-images.githubusercontent.com/22402899/43010184-702df36e-8c48-11e8-8f52-8e7e0c9995dc.png)
