### PR TITLE
Select a whole default text in the input element when the window has been opened

### DIFF
--- a/lib/page/prompt.js
+++ b/lib/page/prompt.js
@@ -102,4 +102,7 @@ docReady(() => {
 	dataEl.setAttribute('id', 'data');
 
 	dataEl.focus();
+	if (promptOptions.type === 'input') {
+		dataEl.select();
+	}
 });


### PR DESCRIPTION
It fixes #23.