### PR TITLE
fix: menu not hidden on Linux

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,6 +48,7 @@ function electronPrompt(options, parentWindow) {
 		});
 
 		promptWindow.setMenu(null);
+		promptWindow.setMenuBarVisibility(false);
 
 		const getOptionsListener = event => {
 			event.returnValue = JSON.stringify(opts);


### PR DESCRIPTION
This fixes a bug where opening a dialogue on Linux only, still has the menubar visible.