### PR TITLE
allow show icon in taskbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ prompt([options, parentBrowserWindow]).then(...).catch(...)
 | icon | (optional, string) The path to an icon image to use in the title bar. Defaults to null and uses electron's icon. |
 | customStylesheet  | (optional, string) The local path of a CSS file to stylize the prompt window. Defaults to null. |
 | menuBarVisible | (optional, boolean) Whether to show the menubar or not. Defaults to false. |
+| skipTaskbar | (optional, boolean) Whether to show the prompt window icon in taskbar. Defaults to true. |
 
 If not supplied, it uses the defaults listed in the table above.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,8 @@ function electronPrompt(options, parentWindow) {
 				icon: null,
 				useHtmlLabel: false,
 				customStylesheet: null,
-				menuBarVisible: false
+				menuBarVisible: false,
+				skipTaskbar: true
 			},
 			options || {}
 		);
@@ -45,7 +46,7 @@ function electronPrompt(options, parentWindow) {
 			minHeight: opts.minHeight,
 			resizable: opts.resizable,
 			parent: parentWindow,
-			skipTaskbar: true,
+			skipTaskbar: opts.skipTaskbar,
 			alwaysOnTop: opts.alwaysOnTop,
 			useContentSize: opts.resizable,
 			modal: Boolean(parentWindow),


### PR DESCRIPTION
allow user to specify if the prompt window is to display icon in taskbar or not
this is helpful on windows for when a user hasnt created a browserwindow but only a tray icon
because when you run prompt, no icon is displayed in taskbar and if user minimizes the prompt window by accident, you cant get prompt box back