### PR TITLE
fix: clicking cancel exits app

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -68,6 +68,10 @@ function electronPrompt(options, parentWindow) {
 		};
 
 		const cleanup = () => {
+			ipcMain.removeListener('prompt-get-options:' + id, getOptionsListener);
+			ipcMain.removeListener('prompt-post-data:' + id, postDataListener);
+			ipcMain.removeListener('prompt-error:' + id, errorListener);
+
 			if (promptWindow) {
 				promptWindow.close();
 				promptWindow = null;
@@ -97,9 +101,8 @@ function electronPrompt(options, parentWindow) {
 		promptWindow.on('unresponsive', unresponsiveListener);
 
 		promptWindow.on('closed', () => {
-			ipcMain.removeListener('prompt-get-options:' + id, getOptionsListener);
-			ipcMain.removeListener('prompt-post-data:' + id, postDataListener);
-			ipcMain.removeListener('prompt-error:' + id, postDataListener);
+			promptWindow = null
+			cleanup()
 			resolve(null);
 		});
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -101,8 +101,8 @@ function electronPrompt(options, parentWindow) {
 		promptWindow.on('unresponsive', unresponsiveListener);
 
 		promptWindow.on('closed', () => {
-			promptWindow = null
-			cleanup()
+			promptWindow = null;
+			cleanup();
 			resolve(null);
 		});
 


### PR DESCRIPTION
I found that clicking cancel would cause my application to exit.
Closing the prompt via escape key, or the window exit would not.

Additionally the `pcMain.removeListener('prompt-error'` was referencing the wrong callback

Tested with electron 9.4.1