### PR TITLE
electron v.12  compatibility

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,7 +56,8 @@ function electronPrompt(options, parentWindow) {
 			title: options_.title,
 			icon: options_.icon || undefined,
 			webPreferences: {
-				nodeIntegration: true
+				nodeIntegration: true,
+				contextIsolation: false,
 			}
 		});
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -57,7 +57,7 @@ function electronPrompt(options, parentWindow) {
 			icon: options_.icon || undefined,
 			webPreferences: {
 				nodeIntegration: true,
-				contextIsolation: false,
+				contextIsolation: false
 			}
 		});
 


### PR DESCRIPTION
[V.12 enables context isolation by default](https://www.electronjs.org/docs/tutorial/context-isolation#how-do-i-enable-it) so  we are required to set it explicitly to false for eg require to work ([v12 came out today](https://github.com/electron/electron/releases/tag/v12.0.0))