### PR TITLE
Remove doc-ready dependency

### DIFF
--- a/lib/page/prompt.js
+++ b/lib/page/prompt.js
@@ -157,4 +157,4 @@ window.addEventListener('error', error => {
 	}
 });
 
-document.addEventListener('DOMContentLoaded', () => promptRegister());
+document.addEventListener('DOMContentLoaded', promptRegister);

--- a/lib/page/prompt.js
+++ b/lib/page/prompt.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const {ipcRenderer} = require('electron');
-const docReady = require('doc-ready');
 
 let promptId = null;
 let promptOptions = null;
@@ -158,4 +157,6 @@ window.addEventListener('error', error => {
 	}
 });
 
-docReady(promptRegister);
+document.addEventListener( 'DOMContentLoaded', function( event ) {
+	promptRegister();
+});

--- a/lib/page/prompt.js
+++ b/lib/page/prompt.js
@@ -157,6 +157,4 @@ window.addEventListener('error', error => {
 	}
 });
 
-document.addEventListener( 'DOMContentLoaded', function( event ) {
-	promptRegister();
-});
+document.addEventListener('DOMContentLoaded', () => promptRegister());

--- a/package.json
+++ b/package.json
@@ -33,9 +33,6 @@
       "unicorn/prefer-ternary": 0
     }
   },
-  "dependencies": {
-    "doc-ready": "^1.0.4"
-  },
   "devDependencies": {
     "xo": "^0.38.2"
   }


### PR DESCRIPTION
The doc-ready project has been abandoned as there is now a standard way to do that same thing.  Please remove this stale dependency.