### PR TITLE
Removed scrollbar and update to only show the prompt once the content…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -78,6 +78,7 @@ function electronPrompt(options, parentWindow) {
 			minimizable: false,
 			fullscreenable: false,
 			maximizable: false,
+			show: false,
 			parent: parentWindow,
 			skipTaskbar: options_.skipTaskbar,
 			alwaysOnTop: options_.alwaysOnTop,
@@ -141,6 +142,11 @@ function electronPrompt(options, parentWindow) {
 			path.join(__dirname, 'page', 'prompt.html'),
 			{hash: id},
 		);
+
+		promptWindow.once('ready-to-show', () => {
+			promptWindow.show();
+		});
+		
 	});
 }
 

--- a/lib/page/prompt.css
+++ b/lib/page/prompt.css
@@ -10,7 +10,7 @@ body {
     justify-content: center;
     display: flex;
     height: 100%;
-    overflow: auto;
+    overflow: hidden;
 }
 
 #form {


### PR DESCRIPTION
Updated, so the prompt is only shown once the contents have been rendered to prevent the user from seeing a brief blank window. See animated gifs below for before and after. Also updated overflow to hidden to remove to scroll bar.

Before
![before](https://user-images.githubusercontent.com/12604077/162600091-4522af58-4146-49d2-a8a1-eacba7b0a4c6.gif)

After
![after](https://user-images.githubusercontent.com/12604077/162600090-cc37e7fb-3ff1-4f31-8c0d-1274c2a6845d.gif)

