### PR TITLE
Remove scrollbar on Windows, add showWhenReady option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ prompt([options, parentBrowserWindow]).then(...).catch(...)
 | customStylesheet  | (optional, string) The local path of a CSS file to stylize the prompt window. Defaults to null. |
 | menuBarVisible | (optional, boolean) Whether to show the menubar or not. Defaults to false. |
 | skipTaskbar | (optional, boolean) Whether to show the prompt window icon in taskbar. Defaults to true. |
-| showWhenReady | (optional, boolean) Whether to only show the prompt window once its content has loaded to avoid an empty prompt from being displayed while the content is loading. Defaults to false. |
+| showWhenReady | (optional, boolean) Whether to only show the prompt window once content is loaded. Defaults to false. |
 
 If not supplied, it uses the defaults listed in the table above.
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ prompt([options, parentBrowserWindow]).then(...).catch(...)
 | customStylesheet  | (optional, string) The local path of a CSS file to stylize the prompt window. Defaults to null. |
 | menuBarVisible | (optional, boolean) Whether to show the menubar or not. Defaults to false. |
 | skipTaskbar | (optional, boolean) Whether to show the prompt window icon in taskbar. Defaults to true. |
+| showWhenReady | (optional, boolean) Whether to only show the prompt window once its content has loaded to avoid an empty prompt from being displayed while the content is loading. Defaults to false. |
 
 If not supplied, it uses the defaults listed in the table above.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -143,7 +143,9 @@ function electronPrompt(options, parentWindow) {
 			{hash: id},
 		);
 
-		promptWindow.once('ready-to-show', () => promptWindow.show());
+		promptWindow.once('ready-to-show', () => {
+			promptWindow.show();
+		});
 		
 	});
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ const path = require('path');
 const electron = require('electron');
 
 const DEFAULT_WIDTH = 370;
-const DEFAULT_HEIGHT = 160;
+const DEFAULT_HEIGHT = 162;
 
 function getElectronMainExport(id) {
 	if (electron[id]) {
@@ -60,6 +60,7 @@ function electronPrompt(options, parentWindow) {
 				customStylesheet: null,
 				menuBarVisible: false,
 				skipTaskbar: true,
+				showWhenReady: false,
 			},
 			options || {},
 		);
@@ -78,7 +79,7 @@ function electronPrompt(options, parentWindow) {
 			minimizable: false,
 			fullscreenable: false,
 			maximizable: false,
-			show: false,
+			show: !options_.showWhenReady,
 			parent: parentWindow,
 			skipTaskbar: options_.skipTaskbar,
 			alwaysOnTop: options_.alwaysOnTop,
@@ -138,14 +139,16 @@ function electronPrompt(options, parentWindow) {
 			resolve(null);
 		});
 
+		if (options_.showWhenReady) {
+			promptWindow.once('ready-to-show', () => {
+				promptWindow.show();
+			});
+		}
+
 		promptWindow.loadFile(
 			path.join(__dirname, 'page', 'prompt.html'),
 			{hash: id},
 		);
-
-		promptWindow.once('ready-to-show', () => {
-			promptWindow.show();
-		});
 	});
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -78,6 +78,7 @@ function electronPrompt(options, parentWindow) {
 			minimizable: false,
 			fullscreenable: false,
 			maximizable: false,
+			show: false,
 			parent: parentWindow,
 			skipTaskbar: options_.skipTaskbar,
 			alwaysOnTop: options_.alwaysOnTop,
@@ -141,6 +142,9 @@ function electronPrompt(options, parentWindow) {
 			path.join(__dirname, 'page', 'prompt.html'),
 			{hash: id},
 		);
+
+		promptWindow.once('ready-to-show', () => promptWindow.show());
+		
 	});
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -146,7 +146,6 @@ function electronPrompt(options, parentWindow) {
 		promptWindow.once('ready-to-show', () => {
 			promptWindow.show();
 		});
-		
 	});
 }
 

--- a/lib/page/prompt.css
+++ b/lib/page/prompt.css
@@ -3,6 +3,7 @@ body {
     line-height: 1.5em;
     color: #333;
     background-color: #fff;
+    margin: 0 8px;
 }
 
 #container {
@@ -10,7 +11,7 @@ body {
     justify-content: center;
     display: flex;
     height: 100%;
-    overflow: hidden;
+    overflow: auto;
 }
 
 #form {

--- a/lib/page/prompt.css
+++ b/lib/page/prompt.css
@@ -10,7 +10,7 @@ body {
     justify-content: center;
     display: flex;
     height: 100%;
-    overflow: auto;
+    overflow: hidden;
 }
 
 #form {


### PR DESCRIPTION
Updated, so the prompt is only shown once the contents have been rendered to prevent the user from seeing a brief blank window. See animated gifs below for before and after. Also updated overflow to hidden to remove to scroll bar.

Before
![before](https://user-images.githubusercontent.com/12604077/162604682-de1d5bb6-f5e1-42af-8719-a9e1e1125bf4.gif)

After
![after](https://user-images.githubusercontent.com/12604077/162604679-970a07cf-7aac-4d27-b82f-ab71a72d6908.gif)









