### PR TITLE
disable devTools web preferences

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -88,6 +88,7 @@ function electronPrompt(options, parentWindow) {
 			title: options_.title,
 			icon: options_.icon || undefined,
 			webPreferences: {
+				devTools: false,
 				nodeIntegration: true,
 				contextIsolation: false,
 			},


### PR DESCRIPTION
I want to disable devTools for prompt window.
But there is no option to achieve this behavior in current version.